### PR TITLE
fix build package removal (#13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,9 @@ RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";"
     && apt-get install -y ${BUILD_PACKAGES} python3 python3-pip curl \
     && curl https://confluence.ecmwf.int/download/attachments/45757960/eccodes-${ECCODES_VER}-Source.tar.gz --output eccodes-${ECCODES_VER}-Source.tar.gz \
     && tar xzf eccodes-${ECCODES_VER}-Source.tar.gz \
-    && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=${ECCODES_DIR} -DENABLE_AEC=OFF ../eccodes-${ECCODES_VER}-Source && make && ctest && make install # \
+    && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=${ECCODES_DIR} -DENABLE_AEC=OFF ../eccodes-${ECCODES_VER}-Source && make && ctest && make install \
     && cd / && rm -rf /tmp/eccodes \
-    && apt-get install python3-eccodes vim vi emacs nano \ 
+    && apt-get install -y python3-eccodes vim emacs nano \
     && apt-get remove --purge -y ${BUILD_PACKAGES} \
     && apt autoremove -y  \
     && apt-get -q clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";"
     && tar xzf eccodes-${ECCODES_VER}-Source.tar.gz \
     && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=${ECCODES_DIR} -DENABLE_AEC=OFF ../eccodes-${ECCODES_VER}-Source && make && ctest && make install \
     && cd / && rm -rf /tmp/eccodes \
-    && apt-get install vim emacs nano \
+    && apt-get install -y vim emacs nano \
     && apt-get remove --purge -y ${BUILD_PACKAGES} \
     && apt autoremove -y  \
     && apt-get -q clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";"
     && tar xzf eccodes-${ECCODES_VER}-Source.tar.gz \
     && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=${ECCODES_DIR} -DENABLE_AEC=OFF ../eccodes-${ECCODES_VER}-Source && make && ctest && make install \
     && cd / && rm -rf /tmp/eccodes \
-    && apt-get install -y python3-eccodes vim emacs nano \
+    && apt-get install vim emacs nano \
     && apt-get remove --purge -y ${BUILD_PACKAGES} \
     && apt autoremove -y  \
     && apt-get -q clean \


### PR DESCRIPTION
Addresses https://github.com/wmo-im/wis2box/issues/883

The commented out commands include pip installing `python3-eccodes`, which I've removed given it was never being used.  If we still want it installed, I can revert accordingly.